### PR TITLE
appointments may be dropped on every 15  minutes

### DIFF
--- a/src/drag-and-drop-library/src/Calendar.js
+++ b/src/drag-and-drop-library/src/Calendar.js
@@ -542,7 +542,7 @@ class Calendar extends React.Component {
    view: views.MONTH,
    views: [views.MONTH, views.WEEK, views.DAY, views.AGENDA, views.RESOURCE, views.STATUS],
    date: now,
-   step: 30,
+   step: 15,
 
    drilldownView: views.DAY,
 


### PR DESCRIPTION
Allows appointment times to snap to 15-minute slots instead of 30-minutes.