### PR TITLE
disallows change of start times

### DIFF
--- a/src/Functions/ScheduleFunctions.js
+++ b/src/Functions/ScheduleFunctions.js
@@ -113,13 +113,9 @@ export function confirmTimeChange(dialogueData, payload, props) {
         message: `${dialogueData.message}`,
         buttons: [
             {
-                label: 'Yes',
+                label: 'OK',
                 onClick: () => dispatchActionToUpdateMovedEvents(payload, props)
             },
-            {
-                label: 'No',
-                onClick: () => alert('Aborted.')
-            }
         ]
     })
 } // END CONFIRM TIME CHANGE

--- a/src/Functions/ScheduleFunctions.js
+++ b/src/Functions/ScheduleFunctions.js
@@ -127,9 +127,11 @@ export function convertAppointmentForSendingToDatabase(updatedObject) {
     let finalObject = {
         "databaseID": updatedObject.databaseID,
         "updates": {
-            "time": moment(updatedObject.start).format('h:mma'),
-            "endTime": moment(updatedObject.start).add(Number(updatedObject.duration), 'm').format('h:mma'),
-            "datetime": moment(updatedObject.start).toDate(),
+            // FUTURE FUNCTIONALITY
+            // "time": moment(updatedObject.start).format('h:mma'),
+            // "endTime": moment(updatedObject.start).add(Number(updatedObject.duration), 'm').format('h:mma'),
+            // "datetime": moment(updatedObject.start).toDate(),
+            // END FUTURE FUNCTIONALITY
             "calendar": updatedObject.calendar,
             "calendarID": updatedObject.calendarID,
         }

--- a/src/components/ScheduleView/ScheduleView.js
+++ b/src/components/ScheduleView/ScheduleView.js
@@ -170,7 +170,7 @@ class ScheduleView extends Component {
         const eventAfterMovedEvent = this.selectEventAfterMovedEventInOrderedArrayOfEvents(arrayOfResourcesWithOrderedArraysOfEvents, event.id);
         // END FIND THE EVENT BEFORE AND AFTER THE MOVED EVENT IN ITS ORDERED ARRAY AFTER IT WAS MOVED
         console.log('dispatching action to update events upon drag and drop')
-        const payload = {
+        let payload = {
             eventAfterMovedEvent: eventAfterMovedEvent,
             eventAfterMovedEventInPreviousArray: eventAfterMovedEventInPreviousArray,
             eventBeforeMovedEvent: eventBeforeMovedEvent,
@@ -183,10 +183,17 @@ class ScheduleView extends Component {
         console.log(updatedMovedEvent.start);
         console.log(event.start - updatedMovedEvent.start);
         if (event.start - updatedMovedEvent.start != 0) {
+            start = event.start;
+            updatedMovedEvent = { ...updatedMovedEvent, start };
             let dialogueData = {
-                title: 'Change times?',
-                message: 'The appointment is dropping into a different start time. \n Do you want to change start times?'
+                title: `Changing calendar to ${updatedMovedEvent.calendar}`,
+                message: `Start time remaining at ${updatedMovedEvent.start}.`
             }
+            payload = {
+                ...payload,
+                updatedMovedEvent
+            }
+            console.log(payload);
             confirmTimeChange(dialogueData, payload, this.props);
         }// END IF MOVED EVENT IS AT A NEW TIME, CONFIRM TIME CHANGE
 
@@ -194,7 +201,7 @@ class ScheduleView extends Component {
         else {
             dispatchActionToUpdateMovedEvents(payload, this.props);
         } // END CASE: MOVED EVENT DOES NOT CHANGE TIMES
-       } // END UPDATE DOM UPON MOVING EVENT
+    } // END UPDATE DOM UPON MOVING EVENT
 
     // ORDER EVENTS IN ARRAYS SORTED BY RESOURCE AND TIME
     orderEventsByResourceAndTime = (resourcesArray, eventsArray) => {


### PR DESCRIPTION
If user drags appointment to new time, the appointment is dropped on the new calendar but at the same time as the original time.